### PR TITLE
Not using @stencil/store

### DIFF
--- a/src/app/components/card/card.component.ts
+++ b/src/app/components/card/card.component.ts
@@ -8,7 +8,5 @@ import store from '../../stores/clicks.store';
   styleUrls: ['./card.component.css']
 })
 export class CardComponent {
-
-  state$$ = store.state;
-
+  state$$ = store;
 }

--- a/src/app/components/page1/page1.component.spec.ts
+++ b/src/app/components/page1/page1.component.spec.ts
@@ -10,9 +10,8 @@ describe('Page1Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ Page1Component ]
-    })
-    .compileComponents();
+      declarations: [Page1Component]
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -22,7 +21,7 @@ describe('Page1Component', () => {
   });
 
   beforeEach(() => {
-    store.dispose();
+    // store.dispose();
   });
 
   it('should create', () => {

--- a/src/app/components/page1/page1.component.ts
+++ b/src/app/components/page1/page1.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 
 import store from '../../stores/clicks.store';
 
-import {AlertService} from '../../services/alert.service';
+import { AlertService } from '../../services/alert.service';
 
 @Component({
   selector: 'app-page1',
@@ -10,23 +10,27 @@ import {AlertService} from '../../services/alert.service';
   styleUrls: ['./page1.component.css']
 })
 export class Page1Component implements OnInit {
-
-  state$$ = store.state;
+  state$$ = store;
 
   oneTimeValue: number;
 
-  constructor(private alertService: AlertService) { }
+  constructor(private alertService: AlertService) {}
 
   ngOnInit(): void {
-    const sub = store.onChange('clicks', (value) => {
-      this.oneTimeValue = value;
 
-      sub();
-    });
+    // This feature does not work with state as a simple object
+    // It could be implemented on the plain object with simple setters which trigger the `onChange`
+    // But as soon as you need that kind of observable state, I would go with a Subject (RxJs)
+
+    // const sub = store.onChange('clicks', value => {
+    //   this.oneTimeValue = value;
+    //
+    //   sub();
+    // });
   }
 
   inc(): void {
-    store.state.clicks++;
+    store.clicks++;
   }
 
   show(): void {
@@ -36,5 +40,4 @@ export class Page1Component implements OnInit {
   reset(): void {
     store.reset();
   }
-
 }

--- a/src/app/services/alert.service.ts
+++ b/src/app/services/alert.service.ts
@@ -6,8 +6,7 @@ import store from '../stores/clicks.store';
   providedIn: 'root'
 })
 export class AlertService {
-
   show(): void {
-    alert(`Count: ${store.state.count}`);
+    alert(`Count: ${store.count}`);
   }
 }

--- a/src/app/stores/clicks.store.ts
+++ b/src/app/stores/clicks.store.ts
@@ -1,12 +1,23 @@
-import {createStore} from '@stencil/store';
+import { createStore } from '@stencil/store';
 
-const { state, onChange, reset, dispose } = createStore({
-    clicks: 0,
-    count: 0
-});
+// const { state, onChange, reset, dispose } = createStore({
+//     clicks: 0,
+//     count: 0
+// });
+//
+// onChange('clicks', value => {
+//     state.count = value * 2;
+// });
+// export default { state, onChange, reset, dispose };
 
-onChange('clicks', value => {
-    state.count = value * 2;
-});
+const state = {
+  clicks: 0,
+  get count(): number {
+    return this.clicks * 2;
+  },
+  reset(): void {
+    this.clicks = 0;
+  }
+};
 
-export default {state, onChange, reset, dispose};
+export default state;


### PR DESCRIPTION
Proof-of-Concept that the whole experiment works with a plain object …
So I don't really think that it makes sense to use @stencil/store at all ...
The point of @stencil/store is to trigger re-rendering of stencil-components ... but you took that away ... What is left is just an object (with a `onChange` notification).
Concerning: click/count: I think it is a good practice to derive state whenever possible, so a getter for count is a better solution than having redundant state.
But if performance is the issue here (the getter is called on each ChangeDetection) then @stencil/store might offer a small advantage. But in that case I personally would look into another solution providing reactive state.